### PR TITLE
feat: Add black and ruff pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-yaml
+    -   id: check-json
+
+-   repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+    -   id: black
+        args: ["-l", "79"]
+        name: black
+        description: "Black: The uncompromising Python code formatter"
+        entry: black
+        language: python
+        minimum_pre_commit_version: 2.9.2
+        require_serial: true
+        types_or: [python, pyi]
+
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.1.14'
+    hooks:
+    -   id: ruff


### PR DESCRIPTION
## PR Type
- [x] 기능 추가

## Change Log
- pre commit yaml 파일 추가 및 설치

## To Reviewer
- black -l 79가 commit 시 자동 적용 됩니다.
- python linter 인 ruff를 사용하여 프로그램의 스타일 오류, 버그 등등을 사전에 표시해줄 수 있습니다.
```
# ruff 와 black 설치
pip3 install ruff black

# pre-commit 설치
pip install pre-commit

# 훅 설치
pre-commit install
```

## Issue Tags
- Closed: #2 